### PR TITLE
Fixed aapt bug with gzip files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+app/**/*.css
+app/**/*.js
+app/**/*.map
+node_modules/
+platforms/
+hooks/

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
         "nativescript-dev-cucumber": "^0.1.1",
         "nativescript-dev-sass": "^0.2.0",
         "nativescript-dev-typescript": "^0.3.2",
+        "node-sass": "3.8.x",
+        "semver": "5.x",
         "tslint": "^3.15.1",
         "typescript": "^1.8.10",
         "wd": "0.4.0"


### PR DESCRIPTION
Added git ignore list
Fixed bug with aapt and gzip files by upgrading semver version to 5.x
Changed node-sass to version 3.8 to reduce file size and number and thus build time
